### PR TITLE
Reverting back to key tree 4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "node": ">=14.0.0"
   },
   "dependencies": {
-    "@metamask/key-tree": "^6.0.0",
+    "@metamask/key-tree": "^4.0.0",
     "ethers": "^5.6.6",
     "js-sha512": "^0.8.0",
     "sinon": "^14.0.1",


### PR DESCRIPTION
Revert key-tree version to 4.0 from 6.0 because deriver breaks