### PR TITLE
Reverting upgrade of metamask snaps cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@metamask/eslint-config": "^8.0.0",
     "@metamask/eslint-config-jest": "^8.0.0",
     "@metamask/eslint-config-nodejs": "^8.0.0",
-    "@metamask/snaps-cli": "^0.23.0",
+    "@metamask/snaps-cli": "^0.18.1",
     "chai": "^4.3.6",
     "coffeescript": "^2.7.0",
     "eslint": "^7.30.0",


### PR DESCRIPTION
Bumping versions of snaps cli and key-tree cause a regression resulting in the snap crashing when trying to generate an account 

Staying on key-tree 4.0.0 and snaps-cli 0.18.1 for now